### PR TITLE
Fix spelling mistakes and format README better

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # RPI4-TM1637
-tutorial on how to connect the TM1637 7seg display to read CPU temps of a raspberry pi 4
+Tutorial on how to connect the TM1637 7-segment display to read CPU temps of a Raspberry Pi (tested on a Pi 4)
 
 # **TM1637 CPU TEMPERATURE DISPLAY**
 
- **HOW TO USE**
+> [!IMPORTANT]
+> Run this to download the library for the TM1637 display
+> ```bash
+> pip3 install raspberrypi-tm1637
+> ```
 
-run `pip3 install raspberrypi-tm1637` to download the librarys.
+## DESCRIPTION
 
-**DESCRIPTION**
-
-This is a python script that reads the CPU temperature from a raspberry pi4 and displays it on a TM1637 7-segment display
-
-
+This is a python script that reads the CPU temperature from a Raspberry Pi and displays it on a TM1637 7-segment display.
 
 ![pinout](https://github.com/user-attachments/assets/c16f9439-a98e-4819-9d0d-9d70a5728912)
 ![example](https://github.com/user-attachments/assets/169be503-f037-4db1-a38f-079428632955)


### PR DESCRIPTION
Better README.md formatting and fixing spelling mistakes.
I used multiline code blocks instead of inline code blocks making it easier for users to copy the command